### PR TITLE
Clarify cross-repository commit reference for otk-202311

### DIFF
--- a/Translations/otk-orkh-202311.adoc
+++ b/Translations/otk-orkh-202311.adoc
@@ -1,7 +1,7 @@
 = Partial Document 202311 of UDTW23 Translated Sentences for Old Turkish language (otk) and Old Turkic script (orkh)
 :toc:
 
-NOTE: This document, titled "UDTW23 Translated Sentences for Old Turkish language (otk) and Old Turkic script (orkh)," is designated with version "202311" to be partial and will no longer receive updates. Any future work or modifications related to the subject matter of this document, particularly authoring for the language and script pair of Old Turkish and Old Turkic, should be pursued by creating a separate document. This approach ensures the content remains consistent and historically accurate as of its last and final update in the link:https://github.com/ud-turkic/udtw23/commit/f449e40e423015d687e69e6bbf421517cff65fb0++[f449e40] commit.
+NOTE: This document, titled "UDTW23 Translated Sentences for Old Turkish language (otk) and Old Turkic script (orkh)," is designated with version "202311" to be partial and will no longer receive updates. Any future work or modifications related to the subject matter of this document, particularly authoring for the language and script pair of Old Turkish and Old Turkic, should be pursued by creating a separate document. This approach ensures the content remains consistent and historically accurate as of its last and final update in the link:++https://github.com/ud-turkic/udtw23/commit/f449e40e423015d687e69e6bbf421517cff65fb0++[udtw23@`f449e40`] commit.
 
 == Conventions
 


### PR DESCRIPTION
This change clarifies the cross-repository commit reference with GitHub standard repo plus at plus commit syntax and fixes AsciiDoc delimiter by placing `++` at the start of the URL, too. TYVM! @furkanakkurt1335 PTAL in case you are maintaining merge processes of PRs.